### PR TITLE
tweaks for nvim and metadata.yaml

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ install: nvimpager.configured $(AUTOLOAD_FILES) $(PLUGIN_FILES) nvimpager.1
 metadata.yaml:
 	echo "---" > $@
 	echo "footer: Version $(VERSION)" >> $@
-	echo "date: $$(git log -1 --format=format:%aI | cut -f 1 -d T)" >> $@
+	#echo "date: $$(git log -1 --format=format:%aI | cut -f 1 -d T)" >> $@
 	echo "..." >> $@
 nvimpager.1: nvimpager.md metadata.yaml
 	pandoc --standalone --to man --output $@ $^
@@ -36,7 +36,7 @@ AnsiEsc.vba:
 	  gunzip > $@
 
 $(PLUGIN_FILES) autoload/AnsiEsc.vim: AnsiEsc.vba
-	nvim -u NONE --headless \
+	nvim -u NONE -n -i tmp --headless \
 	  --cmd 'set rtp^=.' \
 	  --cmd 'packadd vimball' \
 	  --cmd 'runtime plugin/vimballPlugin.vim' \


### PR DESCRIPTION
nvim : do not create swap file
nvim : do not use stock shada location
metadata.yaml : cannot use git log when you have a release