### PR TITLE
Use lowdown instead of pandoc for manpage generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ install it manually, read on.
 * [neovim] ≥ v0.4.0
 * [bash]
 * [busted] (for running the tests)
-* [pandoc] (to build the man page)
+* [pandoc] or [lowdown] (to build the man page)
 
 ### Installation instructions
 
@@ -61,6 +61,9 @@ variables:
 ```sh
 make PREFIX=$HOME/.local install
 ```
+
+You can select between `pandoc` and `lowdown` to generate the man page with the
+`MARKDOWN_PROCESSOR` variable
 
 ## Development
 
@@ -101,5 +104,6 @@ The project is licensed under a BSD-2-clause license.  See the
 [bash]: http://www.gnu.org/software/bash/bash.html
 [busted]: http://olivinelabs.com/busted/
 [pandoc]: http://pandoc.org/
+[lowdown]: https://kristaps.bsd.lv/lowdown/
 [Build Status]: https://travis-ci.org/lucc/nvimpager.svg?branch=develop
 [travis]: https://travis-ci.org/lucc/nvimpager

--- a/nvimpager.md
+++ b/nvimpager.md
@@ -1,9 +1,6 @@
----
 title: NVIMPAGER
 section: 1
-author: Lucas Hoffmann
 header: General Commands Manual
-...
 
 # NAME
 
@@ -124,3 +121,7 @@ git diff
 *nvim*(1) https://github.com/neovim/neovim
 
 *vimpager*(1) https://github.com/rkitover/vimpager
+
+# AUTHORS
+
+Lucas Hoffmann


### PR DESCRIPTION
pandoc is quite hard to build on some platforms, due to depending on the
complicated Haskell toolchain. lowdown is built with C and no
dependencies besides the C library, so it's extremely portable.

This patch adopts metadata in the style supported by lowdown (at least
for now, YAML blocks might yet be supported), with the -m command line
options that are provided since version 0.8.1 of lowdown.

We can remove the "header" item because it's by default what man(1)
displays.

Also make a DATE variable, which can be overriden when building this in
environments without git available, or when building from a tarball.

https://github.com/kristapsdz/lowdown