### PR TITLE
Don't load pack at startup fix #40

### DIFF
--- a/nvimpager
+++ b/nvimpager
@@ -110,7 +110,7 @@ fi
 args1=(
   -R
   ${rc:+-u "$rc"}
-  --cmd 'set rtp+=$RUNTIME | lua nvimpager = require("nvimpager")'
+  --cmd 'set rtp+=$RUNTIME | set packpath= | lua nvimpager = require("nvimpager")'
 )
 # these come after all user supplied -c and --cmd arguments
 args2=(


### PR DESCRIPTION
For `nvim` 0.4.4, `rtp` is set by file `/usr/share/nvim/runtime/plugin/matchit.vim`, which will add nvim default `rtp` as it use `packadd`,

```viml
" Nvim: load the matchit plugin by default.
if stridx(&packpath, $VIMRUNTIME) >= 0
  packadd matchit
endif
```

To disable this feature, we should set packpath to empty. This workaround won't affect `nvimpager`'s default `rtp` value.