### PR TITLE
makefile: Sanitize date output from git log

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ DESTDIR ?=
 PREFIX ?= /usr/local
 RUNTIME = $(PREFIX)/share/nvimpager/runtime
 VERSION = $(lastword $(shell ./nvimpager -v))
-DATE = $(shell git log -1 --pretty="%cs")
+DATE = $(shell git log -1 --no-show-signature --pretty="%cs")
 MARKDOWN_PROCESSOR = pandoc
 BUSTED = busted
 


### PR DESCRIPTION
## Problem

Running `make` on a fresh checkout of this repository will fail if your global Git configuration has signature verification enabled for `git log`. It prints a confusing error message like the following from my PC:

```
$ make
sed 's#^RUNTIME=.*$#RUNTIME='"'/usr/local/share/nvimpager/runtime'"'#;s#version=.*$#version=v0.9-7-g458ca0d#' < nvimpager > nvimpager.configured
chmod +x nvimpager.configured
echo "---" > metadata.yaml
echo "footer: Version v0.9-7-g458ca0d" >> metadata.yaml
echo "date: gpg: Signature made Sat 10 Apr 2021 06:15:09 AM CDT gpg:                using RSA key 4AEE18F83AFDEB23 gpg: Good signature from "GitHub (web-flow commit signing) <noreply@github.com>" [full] 2021-04-10" >> metadata.yaml
/bin/sh: 1: Syntax error: "(" unexpected
make: *** [makefile:31: metadata.yaml] Error 2
```

The problem seems to be either the embedded quotes or embedded parentheses in substring `"GitHub (web-flow commit signing) <noreply@github.com>"`, and the unescaped string at `makefile:31`:

```Makefile
	echo "date: $(DATE)" >> $@
```

## Change

This change simply suppresses signature verification with `git log --no-show-signature` when building the `$(DATE)` string.

## Verification

Now `make` runs to completion:

```
$ make
sed 's#^RUNTIME=.*$#RUNTIME='"'/usr/local/share/nvimpager/runtime'"'#;s#version=.*$#version=v0.9-7-g458ca0d#' < nvimpager > nvimpager.configured
chmod +x nvimpager.configured
echo "---" > metadata.yaml
echo "footer: Version v0.9-7-g458ca0d" >> metadata.yaml
echo "date: 2021-04-10" >> metadata.yaml
echo "..." >> metadata.yaml
pandoc --standalone --to man --output nvimpager.1 nvimpager.md metadata.yaml
mkdir -p /usr/local/bin /usr/local/share/nvimpager/runtime/lua \
  /usr/local/share/man/man1 \
  /usr/local/share/zsh/site-functions
install nvimpager.configured /usr/local/bin/nvimpager
install lua/nvimpager.lua /usr/local/share/nvimpager/runtime/lua
install nvimpager.1 /usr/local/share/man/man1
install _nvimpager /usr/local/share/zsh/site-functions
```

With `metadata.yaml` containing the following:

```
$ cat metadata.yaml
---
footer: Version v0.9-7-g458ca0d
date: 2021-04-10
...
```
## Notes

It may be better (safer) to escape all of the strings constructed via `$(shell ...)` function, as there are probably other configurations that can produce similar errors.