### PR TITLE
Simplify makefile. Use sed instead of cat.

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ install: nvimpager.configured nvimpager.1
 	install _nvimpager $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 
 nvimpager.1: nvimpager.md
-	echo 'nvimpager(1) "nvimpager $(VERSION)"' | cat - $< | scdoc > $@
+	sed '1cnvimpager(1) "nvimpager $(VERSION)"' $< | scdoc > $@
 
 test:
 	@$(BUSTED) test


### PR DESCRIPTION
`sed` is used to add version information to the man page. The also prevents duplication of the first line in the current implementation.