### PR TITLE
hide CSI K sequences

### DIFF
--- a/lua/nvimpager.lua
+++ b/lua/nvimpager.lua
@@ -651,7 +651,7 @@ end
 -- highlights to the buffer instead.
 local function ansi2highlight()
   nvim.nvim_command(
-    "syntax match NvimPagerEscapeSequence conceal '\\e\\[[0-9;]*m'")
+    "syntax match NvimPagerEscapeSequence conceal '\\e\\[[0-9;]*\\(m\\|K[0-2]\\?\\)'")
   nvim.nvim_command("highlight NvimPagerConceal gui=NONE guisp=NONE " ..
 		    "guifg=background guibg=background")
   nvim.nvim_win_set_option(0, "conceallevel", 3)


### PR DESCRIPTION
RE: https://github.com/lucc/nvimpager/commit/87b9742abbf95cd60bd8c6e899b71fc2cdf25470#r97589890

I've no idea how to implement line clearing here, so this just hides the exposed escape sequences