### PR TITLE
Strip whitespaces in detect_man_page_helper

### DIFF
--- a/lua/nvimpager/init.lua
+++ b/lua/nvimpager/init.lua
@@ -78,6 +78,7 @@ end
 ---
 --- @param line string
 local function detect_man_page_helper(line)
+  line = line:gsub('%s+', '')
   if line == "" then return false end
   local index = 1
   while index <= #line do
@@ -87,8 +88,6 @@ local function detect_man_page_helper(line)
     if (cur == third and next == '\b')
       or (cur == '_' and next == '\b' and third ~= nil) then
       index = index + 3  -- continue after the overwriting character
-    elseif cur == " " then
-      index = index + 1
     else
       return false
     end


### PR DESCRIPTION
Attempt to fix #90, which is likely caused by empty lines containing spaces from `git diff` or `hg diff`.

This is a naive attempt, simply stripping all white spaces at the beginning of the `detect_man_page_helper` function (and removing the test on white spaces later, which then serves no purpose).

